### PR TITLE
Fix minor documentation issue causing major headache

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ grunt.initConfig({
                 },
                 detached: true
             },
-            files: 'test_server.js'
+            files: { src: [ 'server/server.js'] }
         }
     },
     stop_node: {
-
+        stop: {}
     }
 });
 ```


### PR DESCRIPTION
1) The previous form of the files declation had no effect
   with current grunt and lead to a hangup (because the loop is empty).

2) Add empty multi-task to enable task
   Newer grunts report "Warning: Task
      "stop_node" failed. Use --force to continue."
   if the configuration does not contain a multi-section entry.
