### PR TITLE
Stop all started node child processes on termination of the Grunt process

### DIFF
--- a/tasks/run_node.js
+++ b/tasks/run_node.js
@@ -59,4 +59,8 @@ module.exports = function (grunt) {
         processList.stop_all();
     });
 
+    // Stopp all started node processes on exit
+    process.on('exit', function(code) {
+        processList.stop_all();
+    });
 };


### PR DESCRIPTION
Ensure that all child node processes are stopped when Grunt exits.

In rare cases one may want that child process outlive the parent process
(like --daemonize). This could be an option.

IMHO the sane default is to sop all processes on exit.
