### PR TITLE
Fix up options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function (grunt) {
             },
             custom_options: {
                 options: {
-                    cwd: 'test',
+                    cwd: '.',
                     stdio: [ 'ignore', 'ignore', 'ignore' ],
                     env: {
                         'foo': 'bar'

--- a/tasks/run_node.js
+++ b/tasks/run_node.js
@@ -35,12 +35,13 @@ module.exports = function (grunt) {
         // mark task as asynchronous
         var done = this.async();
         var options = this.options({
-            cwd: process.cwd,
-            stdio: [ 'ignore', (grunt.option('verbose') ? process.stdout : 'ignore'), process.stderr ],
+            cwd: process.cwd(),
+            stdio: [],
             env: process.env,
             detached: true
         });
         options.env = extend(process.env, options.env);
+        options.stdio = options.stdio || [ 'ignore', (grunt.option('verbose') ? process.stdout : 'ignore'), process.stderr ];
 
         this.files.forEach(function (file) {
             file.src.forEach(function (filepath, index, array) {

--- a/tasks/run_node.js
+++ b/tasks/run_node.js
@@ -8,6 +8,7 @@
 
 'use strict';
 
+var extend = require('util')._extend;
 var processList;
 
 module.exports = function (grunt) {
@@ -33,6 +34,13 @@ module.exports = function (grunt) {
     grunt.registerMultiTask('run_node', 'Start node asynchronously from your grunt build.', function () {
         // mark task as asynchronous
         var done = this.async();
+        var options = this.options({
+            cwd: process.cwd,
+            stdio: [ 'ignore', (grunt.option('verbose') ? process.stdout : 'ignore'), process.stderr ],
+            env: process.env,
+            detached: true
+        });
+        options.env = extend(process.env, options.env);
 
         this.files.forEach(function (file) {
             file.src.forEach(function (filepath, index, array) {
@@ -40,12 +48,7 @@ module.exports = function (grunt) {
                     grunt.log.warn('Source file "' + filepath + '" not found.');
                     done(false);
                 } else {
-                    processList.add('node', [filepath], {
-                        cwd: grunt.option('cwd') || process.cwd(),
-                        stdio: grunt.option('stdio') || [ 'ignore', (grunt.option('verbose') ? process.stdout : 'ignore'), process.stderr ],
-                        env: grunt.option('env'),
-                        detached: grunt.option('detached')
-                    });
+                    processList.add('node', [filepath], options);
                 }
                 // last element
                 if (index === array.length - 1) {


### PR DESCRIPTION
This is the same attempt as #3 - to read the options from the `Gruntfile` properly. The difference is it's a bit more clever about the `env` object and it passed the established tests.