### PR TITLE
Fix child process' path being wrong when cwd option is specified

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function (grunt) {
             },
             custom_options: {
                 options: {
-                    cwd: '.',
+                    cwd: './test/helper',
                     stdio: [ 'ignore', 'ignore', 'ignore' ],
                     env: {
                         'foo': 'bar'

--- a/tasks/run_node.js
+++ b/tasks/run_node.js
@@ -8,6 +8,7 @@
 
 'use strict';
 
+var path = require('path');
 var extend = require('util')._extend;
 var processList;
 
@@ -49,6 +50,10 @@ module.exports = function (grunt) {
                     grunt.log.warn('Source file "' + filepath + '" not found.');
                     done(false);
                 } else {
+                    // amend filepath if cwd is specified
+                    if (options.cwd !== process.cwd()) {
+                        filepath = path.resolve(filepath).replace(path.resolve(options.cwd) + '/', '');
+                    }
                     processList.add('node', [filepath], options);
                 }
                 // last element

--- a/test/run_node_test.js
+++ b/test/run_node_test.js
@@ -56,7 +56,7 @@ exports.run_node = {
         test.expect(1);
         ps = exec('ps -ef | grep -v grep | grep custom_options_server.js | awk \'{ print $8 \" \" $9; }\'',
             function (error, stdout, stderr) {
-                test.equal(stdout, "node test/helper/custom_options_server.js\n", 'check node process is currently running');
+                test.equal(stdout, "node custom_options_server.js\n", 'check node process is currently running');
                 if (error !== null) {
                     grunt.log.error('exec error: ' + error);
                 }


### PR DESCRIPTION
When `cwd` is different than `.`, the `child_process` spawning expects the script filename to be relative to that `cwd`. At the same time, `grunt`'s `files.src` checks that the file exists and there is an internal check for that too. However you set up your options, that use case is not possible and this is an attempt to fix that.

I've currently left the `cwd` be part of the `files.src` path and I'm readjusting the path sent to spawn the child process. There may be a clearer way to define the task options for this use case but I couldn't think of one that wouldn't require some substantial changes to the task itself. Suggestions welcome.